### PR TITLE
[Sample011-Text] TrueType フォントの feature を検証

### DIFF
--- a/Sample011-Text/.gitignore
+++ b/Sample011-Text/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+*.xcworkspace/xcuserdata/*
+*.xcodeproj/xcuserdata/*
+*.xcodeproj/*.xcworkspace/xcuserdata/*

--- a/Sample011-Text/Mintfile
+++ b/Sample011-Text/Mintfile
@@ -1,0 +1,1 @@
+realm/SwiftLint@0.49.1

--- a/Sample011-Text/Sample011-Text.xcodeproj/project.pbxproj
+++ b/Sample011-Text/Sample011-Text.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		52E47AC028E9723E00305350 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 52E47ABF28E9723E00305350 /* Assets.xcassets */; };
 		52E47AC328E9723E00305350 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 52E47AC228E9723E00305350 /* Preview Assets.xcassets */; };
 		52E47ACA28E97AE000305350 /* KerningTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E47AC928E97AE000305350 /* KerningTestView.swift */; };
+		52E47ACC28EAD33400305350 /* FontFeatureTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E47ACB28EAD33400305350 /* FontFeatureTestView.swift */; };
+		52E47ACE28EAD9BD00305350 /* FontFeatureTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E47ACD28EAD9BD00305350 /* FontFeatureTypes.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -21,6 +23,8 @@
 		52E47ABF28E9723E00305350 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		52E47AC228E9723E00305350 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		52E47AC928E97AE000305350 /* KerningTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KerningTestView.swift; sourceTree = "<group>"; };
+		52E47ACB28EAD33400305350 /* FontFeatureTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontFeatureTestView.swift; sourceTree = "<group>"; };
+		52E47ACD28EAD9BD00305350 /* FontFeatureTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontFeatureTypes.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -56,6 +60,8 @@
 				52E47ABB28E9723D00305350 /* Sample011_TextApp.swift */,
 				52E47ABD28E9723D00305350 /* ContentView.swift */,
 				52E47AC928E97AE000305350 /* KerningTestView.swift */,
+				52E47ACB28EAD33400305350 /* FontFeatureTestView.swift */,
+				52E47ACD28EAD9BD00305350 /* FontFeatureTypes.swift */,
 				52E47ABF28E9723E00305350 /* Assets.xcassets */,
 				52E47AC128E9723E00305350 /* Preview Content */,
 			);
@@ -142,6 +148,8 @@
 			files = (
 				52E47ACA28E97AE000305350 /* KerningTestView.swift in Sources */,
 				52E47ABE28E9723D00305350 /* ContentView.swift in Sources */,
+				52E47ACC28EAD33400305350 /* FontFeatureTestView.swift in Sources */,
+				52E47ACE28EAD9BD00305350 /* FontFeatureTypes.swift in Sources */,
 				52E47ABC28E9723D00305350 /* Sample011_TextApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -278,6 +286,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -306,6 +315,7 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Sample011-Text/Sample011-Text.xcodeproj/project.pbxproj
+++ b/Sample011-Text/Sample011-Text.xcodeproj/project.pbxproj
@@ -1,0 +1,346 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		52E47ABC28E9723D00305350 /* Sample011_TextApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E47ABB28E9723D00305350 /* Sample011_TextApp.swift */; };
+		52E47ABE28E9723D00305350 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E47ABD28E9723D00305350 /* ContentView.swift */; };
+		52E47AC028E9723E00305350 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 52E47ABF28E9723E00305350 /* Assets.xcassets */; };
+		52E47AC328E9723E00305350 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 52E47AC228E9723E00305350 /* Preview Assets.xcassets */; };
+		52E47ACA28E97AE000305350 /* KerningTestView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52E47AC928E97AE000305350 /* KerningTestView.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		52E47AB828E9723D00305350 /* Sample011-Text.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Sample011-Text.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		52E47ABB28E9723D00305350 /* Sample011_TextApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sample011_TextApp.swift; sourceTree = "<group>"; };
+		52E47ABD28E9723D00305350 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		52E47ABF28E9723E00305350 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		52E47AC228E9723E00305350 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		52E47AC928E97AE000305350 /* KerningTestView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KerningTestView.swift; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		52E47AB528E9723D00305350 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		52E47AAF28E9723D00305350 = {
+			isa = PBXGroup;
+			children = (
+				52E47ABA28E9723D00305350 /* Sample011-Text */,
+				52E47AB928E9723D00305350 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		52E47AB928E9723D00305350 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				52E47AB828E9723D00305350 /* Sample011-Text.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		52E47ABA28E9723D00305350 /* Sample011-Text */ = {
+			isa = PBXGroup;
+			children = (
+				52E47ABB28E9723D00305350 /* Sample011_TextApp.swift */,
+				52E47ABD28E9723D00305350 /* ContentView.swift */,
+				52E47AC928E97AE000305350 /* KerningTestView.swift */,
+				52E47ABF28E9723E00305350 /* Assets.xcassets */,
+				52E47AC128E9723E00305350 /* Preview Content */,
+			);
+			path = "Sample011-Text";
+			sourceTree = "<group>";
+		};
+		52E47AC128E9723E00305350 /* Preview Content */ = {
+			isa = PBXGroup;
+			children = (
+				52E47AC228E9723E00305350 /* Preview Assets.xcassets */,
+			);
+			path = "Preview Content";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		52E47AB728E9723D00305350 /* Sample011-Text */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 52E47AC628E9723E00305350 /* Build configuration list for PBXNativeTarget "Sample011-Text" */;
+			buildPhases = (
+				52E47AB428E9723D00305350 /* Sources */,
+				52E47AB528E9723D00305350 /* Frameworks */,
+				52E47AB628E9723D00305350 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Sample011-Text";
+			productName = "Sample011-Text";
+			productReference = 52E47AB828E9723D00305350 /* Sample011-Text.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		52E47AB028E9723D00305350 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1410;
+				LastUpgradeCheck = 1410;
+				TargetAttributes = {
+					52E47AB728E9723D00305350 = {
+						CreatedOnToolsVersion = 14.1;
+					};
+				};
+			};
+			buildConfigurationList = 52E47AB328E9723D00305350 /* Build configuration list for PBXProject "Sample011-Text" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 52E47AAF28E9723D00305350;
+			productRefGroup = 52E47AB928E9723D00305350 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				52E47AB728E9723D00305350 /* Sample011-Text */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		52E47AB628E9723D00305350 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				52E47AC328E9723E00305350 /* Preview Assets.xcassets in Resources */,
+				52E47AC028E9723E00305350 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		52E47AB428E9723D00305350 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				52E47ACA28E97AE000305350 /* KerningTestView.swift in Sources */,
+				52E47ABE28E9723D00305350 /* ContentView.swift in Sources */,
+				52E47ABC28E9723D00305350 /* Sample011_TextApp.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		52E47AC428E9723E00305350 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		52E47AC528E9723E00305350 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		52E47AC728E9723E00305350 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Sample011-Text/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.ragingo.ios-samples.Sample011-Text";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		52E47AC828E9723E00305350 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_ASSET_PATHS = "\"Sample011-Text/Preview Content\"";
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.ragingo.ios-samples.Sample011-Text";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		52E47AB328E9723D00305350 /* Build configuration list for PBXProject "Sample011-Text" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				52E47AC428E9723E00305350 /* Debug */,
+				52E47AC528E9723E00305350 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		52E47AC628E9723E00305350 /* Build configuration list for PBXNativeTarget "Sample011-Text" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				52E47AC728E9723E00305350 /* Debug */,
+				52E47AC828E9723E00305350 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 52E47AB028E9723D00305350 /* Project object */;
+}

--- a/Sample011-Text/Sample011-Text.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/Sample011-Text/Sample011-Text.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Sample011-Text/Sample011-Text.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Sample011-Text/Sample011-Text.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Sample011-Text/Sample011-Text/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/Sample011-Text/Sample011-Text/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample011-Text/Sample011-Text/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Sample011-Text/Sample011-Text/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample011-Text/Sample011-Text/Assets.xcassets/Contents.json
+++ b/Sample011-Text/Sample011-Text/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample011-Text/Sample011-Text/ContentView.swift
+++ b/Sample011-Text/Sample011-Text/ContentView.swift
@@ -1,0 +1,26 @@
+//
+//  ContentView.swift
+//  Sample011-Text
+//
+//  Created by ragingo on 2022/10/02.
+//
+
+import SwiftUI
+
+struct ContentView: View {
+    var body: some View {
+        NavigationStack {
+            List {
+                NavigationLink("Kerning") {
+                    KerningTestView()
+                }
+            }
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/Sample011-Text/Sample011-Text/ContentView.swift
+++ b/Sample011-Text/Sample011-Text/ContentView.swift
@@ -9,10 +9,13 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        NavigationStack {
+        NavigationView {
             List {
                 NavigationLink("Kerning") {
                     KerningTestView()
+                }
+                NavigationLink("Font Features") {
+                    FontFeatureTestView()
                 }
             }
         }

--- a/Sample011-Text/Sample011-Text/FontFeatureTestView.swift
+++ b/Sample011-Text/Sample011-Text/FontFeatureTestView.swift
@@ -1,0 +1,375 @@
+//
+//  FontFeatureTestView.swift
+//  Sample011-Text
+//
+//  Created by ragingo on 2022/10/03.
+//
+
+import SwiftUI
+
+/// MEMO
+/// - https://learn.microsoft.com/ja-jp/typography/opentype/spec/features_pt#tag-palt
+/// - https://qiita.com/usagimaru/items/0d3c66618df43df93345#ctfontdescriptorcreatecopywithvariation
+///   - iOS は TrueType ベースの Apple Advanced Typography (AAT)
+///   - palt は無い
+/// - https://developer.apple.com/fonts/TrueType-Reference-Manual/RM09/AppendixF.html
+/// - https://ics.media/entry/14087/
+///   - iPhone Safari & Chrome で palt が効いているのを確認
+/// - 【】 について: https://0g0.org/category/3000-303F/1/
+/// - https://helpx.adobe.com/jp/fonts/using/open-type-syntax.html#palt
+///   - iOS は非対応らしい。ブラウザ側で CoteText で自分で描画しているから palt が効いている？
+/// - https://qiita.com/usagimaru/items/da88c0a8793f23633c28#nsfont--uifont-%E3%81%A7-font-features-%E3%82%92%E5%88%A9%E7%94%A8%E3%81%99%E3%82%8B
+///   - TextEdit.app タイポグラフィーパネルにて全ての「文字間隔」をいじったが、意図した動作をしなかった。
+///     - 「半角」だけ見た目はよさそう。ただ、これを使う場合は隅付き括弧にだけ適用する必要がありそう。
+///     - 「プロポーショナル幅」に期待していたが、全く変化なし
+///
+struct FontFeatureTestView: View {
+    @State private var kerning: CGFloat = 0.0
+
+    @State private var AllTypographicFeatures: FontAllTypographicFeaturesTypeSelectors?
+    @State private var AlternateKana: FontAlternateKanaTypeSelectors?
+    @State private var Annotation: FontAnnotationTypeSelectors?
+    @State private var CaseSensitiveLayout: FontCaseSensitiveLayoutTypeSelectors?
+    @State private var CharacterAlternatives: FontCharacterAlternativesTypeSelectors?
+    @State private var CharacterShape: FontCharacterShapeTypeSelectors?
+    @State private var CJKRomanSpacing: FontCJKRomanSpacingTypeSelectors?
+    @State private var CJKSymbolAlternatives: FontCJKSymbolAlternativesTypeSelectors?
+    @State private var CJKVerticalRomanPlacement: FontCJKVerticalRomanPlacementTypeSelectors?
+    @State private var ContextualAlternates: FontContextualAlternatesTypeSelectors?
+    @State private var CursiveConnection: FontCursiveConnectionTypeSelectors?
+    @State private var DesignComplexity: FontDesignComplexityTypeSelectors?
+    @State private var Diacritics: FontDiacriticsTypeSelectors?
+    @State private var Fractions: FontFractionsTypeSelectors?
+    @State private var IdeographicAlternatives: FontIdeographicAlternativesTypeSelectors?
+    @State private var IdeographicSpacing: FontIdeographicSpacingTypeSelectors?
+    @State private var ItalicCJKRoman: FontItalicCJKRomanTypeSelectors?
+    @State private var KanaSpacing: FontKanaSpacingTypeSelectors?
+    @State private var LetterCase: FontLetterCaseTypeSelectors?
+    @State private var Ligatures: FontLigaturesTypeSelectors?
+    @State private var LinguisticRearrangement: FontLinguisticRearrangementTypeSelectors?
+    @State private var LowerCase: FontLowerCaseTypeSelectors?
+    @State private var MathematicalExtras: FontMathematicalExtrasTypeSelectors?
+    @State private var NumberCase: FontNumberCaseTypeSelectors?
+    @State private var NumberSpacing: FontNumberSpacingTypeSelectors?
+    @State private var OrnamentSets: FontOrnamentSetsTypeSelectors?
+    @State private var OverlappingCharacters: FontOverlappingCharactersTypeSelectors?
+    @State private var RubyKana: FontRubyKanaTypeSelectors?
+    @State private var SmartSwash: FontSmartSwashTypeSelectors?
+    @State private var StyleOptions: FontStyleOptionsTypeSelectors?
+    @State private var StylisticAlternatives: FontStylisticAlternativesTypeSelectors?
+    @State private var TextSpacing: FontTextSpacingTypeSelectors?
+    @State private var Transliteration: FontTransliterationTypeSelectors?
+    @State private var TypographicExtras: FontTypographicExtrasTypeSelectors?
+    @State private var UnicodeDecomposition: FontUnicodeDecompositionTypeSelectors?
+    @State private var UpperCase: FontUpperCaseTypeSelectors?
+    @State private var VerticalPosition: FontVerticalPositionTypeSelectors?
+    @State private var VerticalSubstitution: FontVerticalSubstitutionTypeSelectors?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Button("Reset") {
+                kerning = 0
+                AllTypographicFeatures = nil
+                AlternateKana = nil
+                Annotation = nil
+                CaseSensitiveLayout = nil
+                CharacterAlternatives = nil
+                CharacterShape = nil
+                CJKRomanSpacing = nil
+                CJKSymbolAlternatives = nil
+                CJKVerticalRomanPlacement = nil
+                ContextualAlternates = nil
+                CursiveConnection = nil
+                DesignComplexity = nil
+                Diacritics = nil
+                Fractions = nil
+                IdeographicAlternatives = nil
+                IdeographicSpacing = nil
+                ItalicCJKRoman = nil
+                KanaSpacing = nil
+                LetterCase = nil
+                Ligatures = nil
+                LinguisticRearrangement = nil
+                LowerCase = nil
+                MathematicalExtras = nil
+                NumberCase = nil
+                NumberSpacing = nil
+                OrnamentSets = nil
+                OverlappingCharacters = nil
+                RubyKana = nil
+                SmartSwash = nil
+                StyleOptions = nil
+                StylisticAlternatives = nil
+                TextSpacing = nil
+                Transliteration = nil
+                TypographicExtras = nil
+                UnicodeDecomposition = nil
+                UpperCase = nil
+                VerticalPosition = nil
+                VerticalSubstitution = nil
+            }
+            .buttonStyle(.bordered)
+            .frame(alignment: .center)
+
+            Divider()
+
+            VStack(spacing: 4) {
+                HStack {
+                    Text("Kerning: \(Int(kerning))")
+                    Spacer()
+                }
+                Slider(
+                    value: $kerning,
+                    in: -100.0...100.0,
+                    step: 1.0,
+                    label: { EmptyView() },
+                    minimumValueLabel: { Text("-100") },
+                    maximumValueLabel: { Text("100") }
+                )
+            }
+
+            Group {
+                Divider()
+                HStack {
+                    Spacer()
+                    Text("変更前")
+                        .font(.system(size: 20))
+                        .border(.black)
+                        .background(.orange.opacity(0.2))
+                    Text("変更後")
+                        .font(.system(size: 20))
+                        .border(.black)
+                        .background(.blue.opacity(0.2))
+                    Spacer()
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    makeText(string: "123,456,789", kerning: $kerning)
+                    makeText(string: "Hello, world!", kerning: $kerning)
+                    makeText(string: "ffilw,123,!=", kerning: $kerning)
+                    makeText(string: "あいうえおかきくけこ", kerning: $kerning)
+                    makeText(string: "【あ】い（う）え、お。", kerning: $kerning)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(.horizontal, 8)
+            .background(Color(white: 0.95))
+
+            Divider()
+                .frame(height: 2)
+                .background(Color.black)
+
+            ScrollView {
+                makeSelectorSelectionViews()
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .navigationTitle("Font Features")
+    }
+
+    @ViewBuilder
+    private func makeText(string: String, kerning: Binding<CGFloat>, size: CGFloat = 20.0) -> some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text(string)
+                    .kerning(kerning.wrappedValue)
+                    .font(.system(size: size))
+                    .lineLimit(1)
+                    .border(.black)
+                    .background(.orange.opacity(0.2))
+            }
+
+            HStack {
+                if let font = createFont(size: size) {
+                    Text(string)
+                        .kerning(kerning.wrappedValue)
+                        .font(Font(font))
+                        .lineLimit(1)
+                        .border(.black)
+                        .background(.blue.opacity(0.2))
+                } else {
+                    Text("(T_T)")
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func makeSelectorSelectionView<T: RawRepresentable & CaseIterable>(_ type: T.Type, selectedSelector: Binding<T?>) -> some View where T.RawValue == Int {
+        VStack(spacing: 0) {
+            HStack {
+                let typeName = "\(type)".replacingOccurrences(of: "Font", with: "").replacingOccurrences(of: "TypeSelectors", with: "")
+                Menu(typeName) {
+                    let items = enumToMenuItems(type: type)
+                    ForEach(items) { item in
+                        Button {
+                            selectedSelector.wrappedValue = T(rawValue: item.value)
+                        } label: {
+                            Text("\(item.name): \(item.value)")
+                        }
+                    }
+
+                    Button {
+                        selectedSelector.wrappedValue = nil
+                    } label: {
+                        Text("disable")
+                    }
+                }
+
+                Spacer()
+
+                if let selectedSelector = selectedSelector.wrappedValue {
+                    let name = "\(selectedSelector)"
+                    Text(name)
+                } else {
+                    Text("nil")
+                }
+            }
+        }
+        .padding(.horizontal, 8)
+        .background(Color(white: 0.95))
+        .cornerRadius(4)
+        .font(.system(size: 14))
+    }
+
+    private func createFont(size: CGFloat) -> CTFont? {
+        guard let font = CTFontCreateUIFontForLanguage(.system, size, nil) else {
+            return nil
+        }
+
+        var fontFeatureSettings: [CFDictionary] = []
+
+        if let AllTypographicFeatures { fontFeatureSettings.append(makeAllTypographicFeaturesType(selector: AllTypographicFeatures)) }
+        if let AlternateKana { fontFeatureSettings.append(makeAlternateKanaType(selector: AlternateKana)) }
+        if let Annotation { fontFeatureSettings.append(makeAnnotationType(selector: Annotation)) }
+        if let CaseSensitiveLayout { fontFeatureSettings.append(makeCaseSensitiveLayoutType(selector: CaseSensitiveLayout)) }
+        if let CharacterAlternatives { fontFeatureSettings.append(makeCharacterAlternativesType(selector: CharacterAlternatives)) }
+        if let CharacterShape { fontFeatureSettings.append(makeCharacterShapeType(selector: CharacterShape)) }
+        if let CJKRomanSpacing { fontFeatureSettings.append(makeCJKRomanSpacingType(selector: CJKRomanSpacing)) }
+        if let CJKSymbolAlternatives { fontFeatureSettings.append(makeCJKSymbolAlternativesType(selector: CJKSymbolAlternatives)) }
+        if let CJKVerticalRomanPlacement { fontFeatureSettings.append(makeCJKVerticalRomanPlacementType(selector: CJKVerticalRomanPlacement)) }
+        if let ContextualAlternates { fontFeatureSettings.append(makeContextualAlternatesType(selector: ContextualAlternates)) }
+        if let CursiveConnection { fontFeatureSettings.append(makeCursiveConnectionType(selector: CursiveConnection)) }
+        if let DesignComplexity { fontFeatureSettings.append(makeDesignComplexityType(selector: DesignComplexity)) }
+        if let Diacritics { fontFeatureSettings.append(makeDiacriticsType(selector: Diacritics)) }
+        if let Fractions { fontFeatureSettings.append(makeFractionsType(selector: Fractions)) }
+        if let IdeographicAlternatives { fontFeatureSettings.append(makeIdeographicAlternativesType(selector: IdeographicAlternatives)) }
+        if let IdeographicSpacing { fontFeatureSettings.append(makeIdeographicSpacingType(selector: IdeographicSpacing)) }
+        if let ItalicCJKRoman { fontFeatureSettings.append(makeItalicCJKRomanType(selector: ItalicCJKRoman)) }
+        if let KanaSpacing { fontFeatureSettings.append(makeKanaSpacingType(selector: KanaSpacing)) }
+        if let LetterCase { fontFeatureSettings.append(makeLetterCaseType(selector: LetterCase)) }
+        if let Ligatures { fontFeatureSettings.append(makeLigaturesType(selector: Ligatures)) }
+        if let LinguisticRearrangement { fontFeatureSettings.append(makeLinguisticRearrangementType(selector: LinguisticRearrangement)) }
+        if let LowerCase { fontFeatureSettings.append(makeLowerCaseType(selector: LowerCase)) }
+        if let MathematicalExtras { fontFeatureSettings.append(makeMathematicalExtrasType(selector: MathematicalExtras)) }
+        if let NumberCase { fontFeatureSettings.append(makeNumberCaseType(selector: NumberCase)) }
+        if let NumberSpacing { fontFeatureSettings.append(makeNumberSpacingType(selector: NumberSpacing)) }
+        if let OrnamentSets { fontFeatureSettings.append(makeOrnamentSetsType(selector: OrnamentSets)) }
+        if let OverlappingCharacters { fontFeatureSettings.append(makeOverlappingCharactersType(selector: OverlappingCharacters)) }
+        if let RubyKana { fontFeatureSettings.append(makeRubyKanaType(selector: RubyKana)) }
+        if let SmartSwash { fontFeatureSettings.append(makeSmartSwashType(selector: SmartSwash)) }
+        if let StyleOptions { fontFeatureSettings.append(makeStyleOptionsType(selector: StyleOptions)) }
+        if let StylisticAlternatives { fontFeatureSettings.append(makeStylisticAlternativesType(selector: StylisticAlternatives)) }
+        if let TextSpacing { fontFeatureSettings.append(makeTextSpacingType(selector: TextSpacing)) }
+        if let Transliteration { fontFeatureSettings.append(makeTransliterationType(selector: Transliteration)) }
+        if let TypographicExtras { fontFeatureSettings.append(makeTypographicExtrasType(selector: TypographicExtras)) }
+        if let UnicodeDecomposition { fontFeatureSettings.append(makeUnicodeDecompositionType(selector: UnicodeDecomposition)) }
+        if let UpperCase { fontFeatureSettings.append(makeUpperCaseType(selector: UpperCase)) }
+        if let VerticalPosition { fontFeatureSettings.append(makeVerticalPositionType(selector: VerticalPosition)) }
+        if let VerticalSubstitution { fontFeatureSettings.append(makeVerticalSubstitutionType(selector: VerticalSubstitution)) }
+
+        let fontDescriptor = CTFontDescriptorCreateWithAttributes([
+            kCTFontFeatureSettingsAttribute: fontFeatureSettings
+        ] as CFDictionary)
+
+        let fontWithFeatures = CTFontCreateCopyWithAttributes(font, size, nil, fontDescriptor)
+        return fontWithFeatures
+    }
+
+    @ViewBuilder
+    private func makeSelectorSelectionViews() -> some View {
+        VStack(spacing: 4) {
+            Group {
+                makeSelectorSelectionView(FontAllTypographicFeaturesTypeSelectors.self, selectedSelector: $AllTypographicFeatures)
+                makeSelectorSelectionView(FontAlternateKanaTypeSelectors.self, selectedSelector: $AlternateKana)
+                makeSelectorSelectionView(FontAnnotationTypeSelectors.self, selectedSelector: $Annotation)
+                makeSelectorSelectionView(FontCaseSensitiveLayoutTypeSelectors.self, selectedSelector: $CaseSensitiveLayout)
+                makeSelectorSelectionView(FontCharacterAlternativesTypeSelectors.self, selectedSelector: $CharacterAlternatives)
+                makeSelectorSelectionView(FontCharacterShapeTypeSelectors.self, selectedSelector: $CharacterShape)
+                makeSelectorSelectionView(FontCJKRomanSpacingTypeSelectors.self, selectedSelector: $CJKRomanSpacing)
+                makeSelectorSelectionView(FontCJKSymbolAlternativesTypeSelectors.self, selectedSelector: $CJKSymbolAlternatives)
+                makeSelectorSelectionView(FontCJKVerticalRomanPlacementTypeSelectors.self, selectedSelector: $CJKVerticalRomanPlacement)
+                makeSelectorSelectionView(FontContextualAlternatesTypeSelectors.self, selectedSelector: $ContextualAlternates)
+            }
+            Group {
+                makeSelectorSelectionView(FontCursiveConnectionTypeSelectors.self, selectedSelector: $CursiveConnection)
+                makeSelectorSelectionView(FontDesignComplexityTypeSelectors.self, selectedSelector: $DesignComplexity)
+                makeSelectorSelectionView(FontDiacriticsTypeSelectors.self, selectedSelector: $Diacritics)
+                makeSelectorSelectionView(FontFractionsTypeSelectors.self, selectedSelector: $Fractions)
+                makeSelectorSelectionView(FontIdeographicAlternativesTypeSelectors.self, selectedSelector: $IdeographicAlternatives)
+                makeSelectorSelectionView(FontIdeographicSpacingTypeSelectors.self, selectedSelector: $IdeographicSpacing)
+                makeSelectorSelectionView(FontItalicCJKRomanTypeSelectors.self, selectedSelector: $ItalicCJKRoman)
+                makeSelectorSelectionView(FontKanaSpacingTypeSelectors.self, selectedSelector: $KanaSpacing)
+                makeSelectorSelectionView(FontLetterCaseTypeSelectors.self, selectedSelector: $LetterCase)
+                makeSelectorSelectionView(FontLigaturesTypeSelectors.self, selectedSelector: $Ligatures)
+            }
+            Group {
+                makeSelectorSelectionView(FontLinguisticRearrangementTypeSelectors.self, selectedSelector: $LinguisticRearrangement)
+                makeSelectorSelectionView(FontLowerCaseTypeSelectors.self, selectedSelector: $LowerCase)
+                makeSelectorSelectionView(FontMathematicalExtrasTypeSelectors.self, selectedSelector: $MathematicalExtras)
+                makeSelectorSelectionView(FontNumberCaseTypeSelectors.self, selectedSelector: $NumberCase)
+                makeSelectorSelectionView(FontNumberSpacingTypeSelectors.self, selectedSelector: $NumberSpacing)
+                makeSelectorSelectionView(FontOrnamentSetsTypeSelectors.self, selectedSelector: $OrnamentSets)
+                makeSelectorSelectionView(FontOverlappingCharactersTypeSelectors.self, selectedSelector: $OverlappingCharacters)
+                makeSelectorSelectionView(FontRubyKanaTypeSelectors.self, selectedSelector: $RubyKana)
+                makeSelectorSelectionView(FontSmartSwashTypeSelectors.self, selectedSelector: $SmartSwash)
+                makeSelectorSelectionView(FontStyleOptionsTypeSelectors.self, selectedSelector: $StyleOptions)
+            }
+            Group {
+                makeSelectorSelectionView(FontStylisticAlternativesTypeSelectors.self, selectedSelector: $StylisticAlternatives)
+                makeSelectorSelectionView(FontTextSpacingTypeSelectors.self, selectedSelector: $TextSpacing)
+                makeSelectorSelectionView(FontTransliterationTypeSelectors.self, selectedSelector: $Transliteration)
+                makeSelectorSelectionView(FontTypographicExtrasTypeSelectors.self, selectedSelector: $TypographicExtras)
+                makeSelectorSelectionView(FontUnicodeDecompositionTypeSelectors.self, selectedSelector: $UnicodeDecomposition)
+                makeSelectorSelectionView(FontUpperCaseTypeSelectors.self, selectedSelector: $UpperCase)
+                makeSelectorSelectionView(FontVerticalPositionTypeSelectors.self, selectedSelector: $VerticalPosition)
+                makeSelectorSelectionView(FontVerticalSubstitutionTypeSelectors.self, selectedSelector: $VerticalSubstitution)
+            }
+        }
+    }
+
+    //    private func createFont2(size: CGFloat) -> CTFont? {
+    //        let featureSettings = [
+    //            UIFontDescriptor.FeatureKey.type: kSmartSwashType,
+    //            UIFontDescriptor.FeatureKey.selector: kWordInitialSwashesOnSelector
+    //        ]
+    //        guard let font = UIFont(name: "Hiragino Kaku Gothic ProN", size: size) else {
+    //            return nil
+    //        }
+    //        let desc = font.fontDescriptor.addingAttributes([
+    //            .featureSettings: [
+    //                [
+    //                    UIFontDescriptor.FeatureKey.type: kNumberSpacingType,
+    //                    UIFontDescriptor.FeatureKey.selector: kProportionalNumbersSelector
+    //                ]
+    //            ]
+    //        ])
+    //        return UIFont(descriptor: desc, size: size) as CTFont
+    //    }
+}
+
+private struct MenuItem: Identifiable {
+    let id = UUID()
+    let name: String
+    let value: Int
+}
+
+private func enumToMenuItems<T: RawRepresentable & CaseIterable>(type: T.Type) -> [MenuItem] where T.RawValue == Int {
+    type.allCases.map { MenuItem(name: "\($0)", value: $0.rawValue) }
+}
+
+struct FontFeatureTestView_Previews: PreviewProvider {
+    static var previews: some View {
+        FontFeatureTestView()
+    }
+}

--- a/Sample011-Text/Sample011-Text/FontFeatureTypes.swift
+++ b/Sample011-Text/Sample011-Text/FontFeatureTypes.swift
@@ -1,0 +1,616 @@
+//
+//  FontFeatureTypes.swift
+//  Sample011-Text
+//
+//  Created by ragingo on 2022/10/03.
+//
+
+import Foundation
+import CoreText
+
+func makeAllTypographicFeaturesType(selector: FontAllTypographicFeaturesTypeSelectors) -> CFDictionary { makeFontFeature(type: .kAllTypographicFeaturesType, selector: selector.rawValue) }
+func makeLigaturesType(selector: FontLigaturesTypeSelectors) -> CFDictionary { makeFontFeature(type: .kLigaturesType, selector: selector.rawValue) }
+func makeCursiveConnectionType(selector: FontCursiveConnectionTypeSelectors) -> CFDictionary { makeFontFeature(type: .kCursiveConnectionType, selector: selector.rawValue) }
+func makeLetterCaseType(selector: FontLetterCaseTypeSelectors) -> CFDictionary { makeFontFeature(type: .kLetterCaseType, selector: selector.rawValue) }
+func makeVerticalSubstitutionType(selector: FontVerticalSubstitutionTypeSelectors) -> CFDictionary { makeFontFeature(type: .kVerticalSubstitutionType, selector: selector.rawValue) }
+func makeLinguisticRearrangementType(selector: FontLinguisticRearrangementTypeSelectors) -> CFDictionary { makeFontFeature(type: .kLinguisticRearrangementType, selector: selector.rawValue) }
+func makeNumberSpacingType(selector: FontNumberSpacingTypeSelectors) -> CFDictionary { makeFontFeature(type: .kNumberSpacingType, selector: selector.rawValue) }
+func makeSmartSwashType(selector: FontSmartSwashTypeSelectors) -> CFDictionary { makeFontFeature(type: .kSmartSwashType, selector: selector.rawValue) }
+func makeDiacriticsType(selector: FontDiacriticsTypeSelectors) -> CFDictionary { makeFontFeature(type: .kDiacriticsType, selector: selector.rawValue) }
+func makeVerticalPositionType(selector: FontVerticalPositionTypeSelectors) -> CFDictionary { makeFontFeature(type: .kVerticalPositionType, selector: selector.rawValue) }
+func makeFractionsType(selector: FontFractionsTypeSelectors) -> CFDictionary { makeFontFeature(type: .kFractionsType, selector: selector.rawValue) }
+func makeOverlappingCharactersType(selector: FontOverlappingCharactersTypeSelectors) -> CFDictionary { makeFontFeature(type: .kOverlappingCharactersType, selector: selector.rawValue) }
+func makeTypographicExtrasType(selector: FontTypographicExtrasTypeSelectors) -> CFDictionary { makeFontFeature(type: .kTypographicExtrasType, selector: selector.rawValue) }
+func makeMathematicalExtrasType(selector: FontMathematicalExtrasTypeSelectors) -> CFDictionary { makeFontFeature(type: .kMathematicalExtrasType, selector: selector.rawValue) }
+func makeOrnamentSetsType(selector: FontOrnamentSetsTypeSelectors) -> CFDictionary { makeFontFeature(type: .kOrnamentSetsType, selector: selector.rawValue) }
+func makeCharacterAlternativesType(selector: FontCharacterAlternativesTypeSelectors) -> CFDictionary { makeFontFeature(type: .kCharacterAlternativesType, selector: selector.rawValue) }
+func makeDesignComplexityType(selector: FontDesignComplexityTypeSelectors) -> CFDictionary { makeFontFeature(type: .kDesignComplexityType, selector: selector.rawValue) }
+func makeStyleOptionsType(selector: FontStyleOptionsTypeSelectors) -> CFDictionary { makeFontFeature(type: .kStyleOptionsType, selector: selector.rawValue) }
+func makeCharacterShapeType(selector: FontCharacterShapeTypeSelectors) -> CFDictionary { makeFontFeature(type: .kCharacterShapeType, selector: selector.rawValue) }
+func makeNumberCaseType(selector: FontNumberCaseTypeSelectors) -> CFDictionary { makeFontFeature(type: .kNumberCaseType, selector: selector.rawValue) }
+func makeTextSpacingType(selector: FontTextSpacingTypeSelectors) -> CFDictionary { makeFontFeature(type: .kTextSpacingType, selector: selector.rawValue) }
+func makeTransliterationType(selector: FontTransliterationTypeSelectors) -> CFDictionary { makeFontFeature(type: .kTransliterationType, selector: selector.rawValue) }
+func makeAnnotationType(selector: FontAnnotationTypeSelectors) -> CFDictionary { makeFontFeature(type: .kAnnotationType, selector: selector.rawValue) }
+func makeKanaSpacingType(selector: FontKanaSpacingTypeSelectors) -> CFDictionary { makeFontFeature(type: .kKanaSpacingType, selector: selector.rawValue) }
+func makeIdeographicSpacingType(selector: FontIdeographicSpacingTypeSelectors) -> CFDictionary { makeFontFeature(type: .kIdeographicSpacingType, selector: selector.rawValue) }
+func makeUnicodeDecompositionType(selector: FontUnicodeDecompositionTypeSelectors) -> CFDictionary { makeFontFeature(type: .kUnicodeDecompositionType, selector: selector.rawValue) }
+func makeRubyKanaType(selector: FontRubyKanaTypeSelectors) -> CFDictionary { makeFontFeature(type: .kRubyKanaType, selector: selector.rawValue) }
+func makeCJKSymbolAlternativesType(selector: FontCJKSymbolAlternativesTypeSelectors) -> CFDictionary { makeFontFeature(type: .kCJKSymbolAlternativesType, selector: selector.rawValue) }
+func makeIdeographicAlternativesType(selector: FontIdeographicAlternativesTypeSelectors) -> CFDictionary { makeFontFeature(type: .kIdeographicAlternativesType, selector: selector.rawValue) }
+func makeCJKVerticalRomanPlacementType(selector: FontCJKVerticalRomanPlacementTypeSelectors) -> CFDictionary { makeFontFeature(type: .kCJKVerticalRomanPlacementType, selector: selector.rawValue) }
+func makeItalicCJKRomanType(selector: FontItalicCJKRomanTypeSelectors) -> CFDictionary { makeFontFeature(type: .kItalicCJKRomanType, selector: selector.rawValue) }
+func makeCaseSensitiveLayoutType(selector: FontCaseSensitiveLayoutTypeSelectors) -> CFDictionary { makeFontFeature(type: .kCaseSensitiveLayoutType, selector: selector.rawValue) }
+func makeAlternateKanaType(selector: FontAlternateKanaTypeSelectors) -> CFDictionary { makeFontFeature(type: .kAlternateKanaType, selector: selector.rawValue) }
+func makeStylisticAlternativesType(selector: FontStylisticAlternativesTypeSelectors) -> CFDictionary { makeFontFeature(type: .kStylisticAlternativesType, selector: selector.rawValue) }
+func makeContextualAlternatesType(selector: FontContextualAlternatesTypeSelectors) -> CFDictionary { makeFontFeature(type: .kContextualAlternatesType, selector: selector.rawValue) }
+func makeLowerCaseType(selector: FontLowerCaseTypeSelectors) -> CFDictionary { makeFontFeature(type: .kLowerCaseType, selector: selector.rawValue) }
+func makeUpperCaseType(selector: FontUpperCaseTypeSelectors) -> CFDictionary { makeFontFeature(type: .kUpperCaseType, selector: selector.rawValue) }
+func makeCJKRomanSpacingType(selector: FontCJKRomanSpacingTypeSelectors) -> CFDictionary { makeFontFeature(type: .kCJKRomanSpacingType, selector: selector.rawValue) }
+
+func makeFontFeature(type: FontFeatureType, selector: Int) -> CFDictionary {
+    [
+        kCTFontFeatureTypeIdentifierKey: type.rawValue,
+        kCTFontFeatureSelectorIdentifierKey: selector
+    ] as CFDictionary
+}
+
+// https://developer.apple.com/fonts/TrueType-Reference-Manual/RM09/AppendixF.html
+
+enum FontFeatureType: Int, CaseIterable {
+    case kAllTypographicFeaturesType    = 0
+    case kLigaturesType                 = 1
+    case kCursiveConnectionType         = 2
+    case kLetterCaseType                = 3    /* deprecated - use kLowerCaseType or kUpperCaseType instead */
+    case kVerticalSubstitutionType      = 4
+    case kLinguisticRearrangementType   = 5
+    case kNumberSpacingType             = 6
+    case kSmartSwashType                = 8
+    case kDiacriticsType                = 9
+    case kVerticalPositionType          = 10
+    case kFractionsType                 = 11
+    case kOverlappingCharactersType     = 13
+    case kTypographicExtrasType         = 14
+    case kMathematicalExtrasType        = 15
+    case kOrnamentSetsType              = 16
+    case kCharacterAlternativesType     = 17
+    case kDesignComplexityType          = 18
+    case kStyleOptionsType              = 19
+    case kCharacterShapeType            = 20
+    case kNumberCaseType                = 21
+    case kTextSpacingType               = 22
+    case kTransliterationType           = 23
+    case kAnnotationType                = 24
+    case kKanaSpacingType               = 25
+    case kIdeographicSpacingType        = 26
+    case kUnicodeDecompositionType      = 27
+    case kRubyKanaType                  = 28
+    case kCJKSymbolAlternativesType     = 29
+    case kIdeographicAlternativesType   = 30
+    case kCJKVerticalRomanPlacementType = 31
+    case kItalicCJKRomanType            = 32
+    case kCaseSensitiveLayoutType       = 33
+    case kAlternateKanaType             = 34
+    case kStylisticAlternativesType     = 35
+    case kContextualAlternatesType      = 36
+    case kLowerCaseType                 = 37
+    case kUpperCaseType                 = 38
+    case kLanguageTagType               = 39
+    case kCJKRomanSpacingType           = 103
+    case kLastFeatureType               = -1
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kAllTypographicFeaturesType
+ */
+enum FontAllTypographicFeaturesTypeSelectors: Int, CaseIterable {
+    case kAllTypeFeaturesOnSelector  = 0
+    case kAllTypeFeaturesOffSelector = 1
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kLigaturesType
+ */
+enum FontLigaturesTypeSelectors: Int, CaseIterable {
+    case kRequiredLigaturesOnSelector       = 0
+    case kRequiredLigaturesOffSelector      = 1
+    case kCommonLigaturesOnSelector         = 2
+    case kCommonLigaturesOffSelector        = 3
+    case kRareLigaturesOnSelector           = 4
+    case kRareLigaturesOffSelector          = 5
+    case kLogosOnSelector                   = 6
+    case kLogosOffSelector                  = 7
+    case kRebusPicturesOnSelector           = 8
+    case kRebusPicturesOffSelector          = 9
+    case kDiphthongLigaturesOnSelector      = 10
+    case kDiphthongLigaturesOffSelector     = 11
+    case kSquaredLigaturesOnSelector        = 12
+    case kSquaredLigaturesOffSelector       = 13
+    case kAbbrevSquaredLigaturesOnSelector  = 14
+    case kAbbrevSquaredLigaturesOffSelector = 15
+    case kSymbolLigaturesOnSelector         = 16
+    case kSymbolLigaturesOffSelector        = 17
+    case kContextualLigaturesOnSelector     = 18
+    case kContextualLigaturesOffSelector    = 19
+    case kHistoricalLigaturesOnSelector     = 20
+    case kHistoricalLigaturesOffSelector    = 21
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kCursiveConnectionType
+ */
+enum FontCursiveConnectionTypeSelectors: Int, CaseIterable {
+    case kUnconnectedSelector        = 0
+    case kPartiallyConnectedSelector = 1
+    case kCursiveSelector            = 2
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kLetterCaseType
+ */
+enum FontLetterCaseTypeSelectors: Int, CaseIterable {
+    case kUpperAndLowerCaseSelector       = 0    /* deprecated */
+    case kAllCapsSelector                 = 1    /* deprecated */
+    case kAllLowerCaseSelector            = 2    /* deprecated */
+    case kSmallCapsSelector               = 3    /* deprecated */
+    case kInitialCapsSelector             = 4    /* deprecated */
+    case kInitialCapsAndSmallCapsSelector = 5    /* deprecated */
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kVerticalSubstitutionType
+ */
+enum FontVerticalSubstitutionTypeSelectors: Int, CaseIterable {
+    case kSubstituteVerticalFormsOnSelector  = 0
+    case kSubstituteVerticalFormsOffSelector = 1
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kLinguisticRearrangementType
+ */
+enum FontLinguisticRearrangementTypeSelectors: Int, CaseIterable {
+    case kLinguisticRearrangementOnSelector  = 0
+    case kLinguisticRearrangementOffSelector = 1
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kNumberSpacingType
+ */
+enum FontNumberSpacingTypeSelectors: Int, CaseIterable {
+    case kMonospacedNumbersSelector   = 0
+    case kProportionalNumbersSelector = 1
+    case kThirdWidthNumbersSelector   = 2
+    case kQuarterWidthNumbersSelector = 3
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kSmartSwashType
+ */
+enum FontSmartSwashTypeSelectors: Int, CaseIterable {
+    case kWordInitialSwashesOnSelector  = 0
+    case kWordInitialSwashesOffSelector = 1
+    case kWordFinalSwashesOnSelector    = 2
+    case kWordFinalSwashesOffSelector   = 3
+    case kLineInitialSwashesOnSelector  = 4
+    case kLineInitialSwashesOffSelector = 5
+    case kLineFinalSwashesOnSelector    = 6
+    case kLineFinalSwashesOffSelector   = 7
+    case kNonFinalSwashesOnSelector     = 8
+    case kNonFinalSwashesOffSelector    = 9
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kDiacriticsType
+ */
+enum FontDiacriticsTypeSelectors: Int, CaseIterable {
+    case kShowDiacriticsSelector      = 0
+    case kHideDiacriticsSelector      = 1
+    case kDecomposeDiacriticsSelector = 2
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kVerticalPositionType
+ */
+enum FontVerticalPositionTypeSelectors: Int, CaseIterable {
+    case kNormalPositionSelector      = 0
+    case kSuperiorsSelector           = 1
+    case kInferiorsSelector           = 2
+    case kOrdinalsSelector            = 3
+    case kScientificInferiorsSelector = 4
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kFractionsType
+ */
+enum FontFractionsTypeSelectors: Int, CaseIterable {
+    case kNoFractionsSelector       = 0
+    case kVerticalFractionsSelector = 1
+    case kDiagonalFractionsSelector = 2
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kOverlappingCharactersType
+ */
+enum FontOverlappingCharactersTypeSelectors: Int, CaseIterable {
+    case kPreventOverlapOnSelector  = 0
+    case kPreventOverlapOffSelector = 1
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kTypographicExtrasType
+ */
+enum FontTypographicExtrasTypeSelectors: Int, CaseIterable {
+    case kHyphensToEmDashOnSelector    = 0
+    case kHyphensToEmDashOffSelector   = 1
+    case kHyphenToEnDashOnSelector     = 2
+    case kHyphenToEnDashOffSelector    = 3
+    case kSlashedZeroOnSelector        = 4
+    case kSlashedZeroOffSelector       = 5
+    case kFormInterrobangOnSelector    = 6
+    case kFormInterrobangOffSelector   = 7
+    case kSmartQuotesOnSelector        = 8
+    case kSmartQuotesOffSelector       = 9
+    case kPeriodsToEllipsisOnSelector  = 10
+    case kPeriodsToEllipsisOffSelector = 11
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kMathematicalExtrasType
+ */
+enum FontMathematicalExtrasTypeSelectors: Int, CaseIterable {
+    case kHyphenToMinusOnSelector        = 0
+    case kHyphenToMinusOffSelector       = 1
+    case kAsteriskToMultiplyOnSelector   = 2
+    case kAsteriskToMultiplyOffSelector  = 3
+    case kSlashToDivideOnSelector        = 4
+    case kSlashToDivideOffSelector       = 5
+    case kInequalityLigaturesOnSelector  = 6
+    case kInequalityLigaturesOffSelector = 7
+    case kExponentsOnSelector            = 8
+    case kExponentsOffSelector           = 9
+    case kMathematicalGreekOnSelector    = 10
+    case kMathematicalGreekOffSelector   = 11
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kOrnamentSetsType
+ */
+enum FontOrnamentSetsTypeSelectors: Int, CaseIterable {
+    case kNoOrnamentsSelector          = 0
+    case kDingbatsSelector             = 1
+    case kPiCharactersSelector         = 2
+    case kFleuronsSelector             = 3
+    case kDecorativeBordersSelector    = 4
+    case kInternationalSymbolsSelector = 5
+    case kMathSymbolsSelector          = 6
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kCharacterAlternativesType
+ */
+enum FontCharacterAlternativesTypeSelectors: Int, CaseIterable {
+    case kNoAlternatesSelector = 0
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kDesignComplexityType
+ */
+enum FontDesignComplexityTypeSelectors: Int, CaseIterable {
+    case kDesignLevel1Selector = 0
+    case kDesignLevel2Selector = 1
+    case kDesignLevel3Selector = 2
+    case kDesignLevel4Selector = 3
+    case kDesignLevel5Selector = 4
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kStyleOptionsType
+ */
+enum FontStyleOptionsTypeSelectors: Int, CaseIterable {
+    case kNoStyleOptionsSelector  = 0
+    case kDisplayTextSelector     = 1
+    case kEngravedTextSelector    = 2
+    case kIlluminatedCapsSelector = 3
+    case kTitlingCapsSelector     = 4
+    case kTallCapsSelector        = 5
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kCharacterShapeType
+ */
+enum FontCharacterShapeTypeSelectors: Int, CaseIterable {
+    case kTraditionalCharactersSelector      = 0
+    case kSimplifiedCharactersSelector       = 1
+    case kJIS1978CharactersSelector          = 2
+    case kJIS1983CharactersSelector          = 3
+    case kJIS1990CharactersSelector          = 4
+    case kTraditionalAltOneSelector          = 5
+    case kTraditionalAltTwoSelector          = 6
+    case kTraditionalAltThreeSelector        = 7
+    case kTraditionalAltFourSelector         = 8
+    case kTraditionalAltFiveSelector         = 9
+    case kExpertCharactersSelector           = 10
+    case kJIS2004CharactersSelector          = 11
+    case kHojoCharactersSelector             = 12
+    case kNLCCharactersSelector              = 13
+    case kTraditionalNamesCharactersSelector = 14
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kNumberCaseType
+ */
+enum FontNumberCaseTypeSelectors: Int, CaseIterable {
+    case kLowerCaseNumbersSelector = 0
+    case kUpperCaseNumbersSelector = 1
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kTextSpacingType
+ */
+enum FontTextSpacingTypeSelectors: Int, CaseIterable {
+    case kProportionalTextSelector    = 0
+    case kMonospacedTextSelector      = 1
+    case kHalfWidthTextSelector       = 2
+    case kThirdWidthTextSelector      = 3
+    case kQuarterWidthTextSelector    = 4
+    case kAltProportionalTextSelector = 5
+    case kAltHalfWidthTextSelector    = 6
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kTransliterationType
+ */
+enum FontTransliterationTypeSelectors: Int, CaseIterable {
+    case kNoTransliterationSelector      = 0
+    case kHanjaToHangulSelector          = 1
+    case kHiraganaToKatakanaSelector     = 2
+    case kKatakanaToHiraganaSelector     = 3
+    case kKanaToRomanizationSelector     = 4
+    case kRomanizationToHiraganaSelector = 5
+    case kRomanizationToKatakanaSelector = 6
+    case kHanjaToHangulAltOneSelector    = 7
+    case kHanjaToHangulAltTwoSelector    = 8
+    case kHanjaToHangulAltThreeSelector  = 9
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kAnnotationType
+ */
+enum FontAnnotationTypeSelectors: Int, CaseIterable {
+    case kNoAnnotationSelector                 = 0
+    case kBoxAnnotationSelector                = 1
+    case kRoundedBoxAnnotationSelector         = 2
+    case kCircleAnnotationSelector             = 3
+    case kInvertedCircleAnnotationSelector     = 4
+    case kParenthesisAnnotationSelector        = 5
+    case kPeriodAnnotationSelector             = 6
+    case kRomanNumeralAnnotationSelector       = 7
+    case kDiamondAnnotationSelector            = 8
+    case kInvertedBoxAnnotationSelector        = 9
+    case kInvertedRoundedBoxAnnotationSelector = 10
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kKanaSpacingType
+ */
+enum FontKanaSpacingTypeSelectors: Int, CaseIterable {
+    case kFullWidthKanaSelector    = 0
+    case kProportionalKanaSelector = 1
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kIdeographicSpacingType
+ */
+enum FontIdeographicSpacingTypeSelectors: Int, CaseIterable {
+    case kFullWidthIdeographsSelector    = 0
+    case kProportionalIdeographsSelector = 1
+    case kHalfWidthIdeographsSelector    = 2
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kUnicodeDecompositionType
+ */
+enum FontUnicodeDecompositionTypeSelectors: Int, CaseIterable {
+    case kCanonicalCompositionOnSelector      = 0
+    case kCanonicalCompositionOffSelector     = 1
+    case kCompatibilityCompositionOnSelector  = 2
+    case kCompatibilityCompositionOffSelector = 3
+    case kTranscodingCompositionOnSelector    = 4
+    case kTranscodingCompositionOffSelector   = 5
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kRubyKanaType
+ */
+enum FontRubyKanaTypeSelectors: Int, CaseIterable {
+    case kNoRubyKanaSelector  = 0    /* deprecated - use kRubyKanaOffSelector instead */
+    case kRubyKanaSelector    = 1    /* deprecated - use kRubyKanaOnSelector instead */
+    case kRubyKanaOnSelector  = 2
+    case kRubyKanaOffSelector = 3
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kCJKSymbolAlternativesType
+ */
+enum FontCJKSymbolAlternativesTypeSelectors: Int, CaseIterable {
+    case kNoCJKSymbolAlternativesSelector = 0
+    case kCJKSymbolAltOneSelector         = 1
+    case kCJKSymbolAltTwoSelector         = 2
+    case kCJKSymbolAltThreeSelector       = 3
+    case kCJKSymbolAltFourSelector        = 4
+    case kCJKSymbolAltFiveSelector        = 5
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kIdeographicAlternativesType
+ */
+enum FontIdeographicAlternativesTypeSelectors: Int, CaseIterable {
+    case kNoIdeographicAlternativesSelector = 0
+    case kIdeographicAltOneSelector         = 1
+    case kIdeographicAltTwoSelector         = 2
+    case kIdeographicAltThreeSelector       = 3
+    case kIdeographicAltFourSelector        = 4
+    case kIdeographicAltFiveSelector        = 5
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kCJKVerticalRomanPlacementType
+ */
+enum FontCJKVerticalRomanPlacementTypeSelectors: Int, CaseIterable {
+    case kCJKVerticalRomanCenteredSelector  = 0
+    case kCJKVerticalRomanHBaselineSelector = 1
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kItalicCJKRomanType
+ */
+enum FontItalicCJKRomanTypeSelectors: Int, CaseIterable {
+    case kNoCJKItalicRomanSelector  = 0    /* deprecated - use kCJKItalicRomanOffSelector instead */
+    case kCJKItalicRomanSelector    = 1    /* deprecated - use kCJKItalicRomanOnSelector instead */
+    case kCJKItalicRomanOnSelector  = 2
+    case kCJKItalicRomanOffSelector = 3
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kCaseSensitiveLayoutType
+ */
+enum FontCaseSensitiveLayoutTypeSelectors: Int, CaseIterable {
+    case kCaseSensitiveLayoutOnSelector   = 0
+    case kCaseSensitiveLayoutOffSelector  = 1
+    case kCaseSensitiveSpacingOnSelector  = 2
+    case kCaseSensitiveSpacingOffSelector = 3
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kAlternateKanaType
+ */
+enum FontAlternateKanaTypeSelectors: Int, CaseIterable {
+    case kAlternateHorizKanaOnSelector  = 0
+    case kAlternateHorizKanaOffSelector = 1
+    case kAlternateVertKanaOnSelector   = 2
+    case kAlternateVertKanaOffSelector  = 3
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kStylisticAlternativesType
+ */
+enum FontStylisticAlternativesTypeSelectors: Int, CaseIterable {
+    case kNoStylisticAlternatesSelector = 0
+    case kStylisticAltOneOnSelector = 2
+    case kStylisticAltOneOffSelector = 3
+    case kStylisticAltTwoOnSelector = 4
+    case kStylisticAltTwoOffSelector = 5
+    case kStylisticAltThreeOnSelector = 6
+    case kStylisticAltThreeOffSelector = 7
+    case kStylisticAltFourOnSelector = 8
+    case kStylisticAltFourOffSelector = 9
+    case kStylisticAltFiveOnSelector = 10
+    case kStylisticAltFiveOffSelector = 11
+    case kStylisticAltSixOnSelector = 12
+    case kStylisticAltSixOffSelector = 13
+    case kStylisticAltSevenOnSelector = 14
+    case kStylisticAltSevenOffSelector = 15
+    case kStylisticAltEightOnSelector = 16
+    case kStylisticAltEightOffSelector = 17
+    case kStylisticAltNineOnSelector = 18
+    case kStylisticAltNineOffSelector = 19
+    case kStylisticAltTenOnSelector = 20
+    case kStylisticAltTenOffSelector = 21
+    case kStylisticAltElevenOnSelector = 22
+    case kStylisticAltElevenOffSelector = 23
+    case kStylisticAltTwelveOnSelector = 24
+    case kStylisticAltTwelveOffSelector = 25
+    case kStylisticAltThirteenOnSelector = 26
+    case kStylisticAltThirteenOffSelector = 27
+    case kStylisticAltFourteenOnSelector = 28
+    case kStylisticAltFourteenOffSelector = 29
+    case kStylisticAltFifteenOnSelector = 30
+    case kStylisticAltFifteenOffSelector = 31
+    case kStylisticAltSixteenOnSelector = 32
+    case kStylisticAltSixteenOffSelector = 33
+    case kStylisticAltSeventeenOnSelector = 34
+    case kStylisticAltSeventeenOffSelector = 35
+    case kStylisticAltEighteenOnSelector = 36
+    case kStylisticAltEighteenOffSelector = 37
+    case kStylisticAltNineteenOnSelector = 38
+    case kStylisticAltNineteenOffSelector = 39
+    case kStylisticAltTwentyOnSelector = 40
+    case kStylisticAltTwentyOffSelector = 41
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kContextualAlternatesType
+ */
+enum FontContextualAlternatesTypeSelectors: Int, CaseIterable {
+    case kContextualAlternatesOnSelector       = 0
+    case kContextualAlternatesOffSelector      = 1
+    case kSwashAlternatesOnSelector            = 2
+    case kSwashAlternatesOffSelector           = 3
+    case kContextualSwashAlternatesOnSelector  = 4
+    case kContextualSwashAlternatesOffSelector = 5
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kLowerCaseType
+ */
+enum FontLowerCaseTypeSelectors: Int, CaseIterable {
+    case kDefaultLowerCaseSelector    = 0
+    case kLowerCaseSmallCapsSelector  = 1
+    case kLowerCasePetiteCapsSelector = 2
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kUpperCaseType
+ */
+enum FontUpperCaseTypeSelectors: Int, CaseIterable {
+    case kDefaultUpperCaseSelector    = 0
+    case kUpperCaseSmallCapsSelector  = 1
+    case kUpperCasePetiteCapsSelector = 2
+}
+
+/*
+ *    Summary:
+ *    Selectors for feature type kCJKRomanSpacingType
+ */
+enum FontCJKRomanSpacingTypeSelectors: Int, CaseIterable {
+    case kHalfWidthCJKRomanSelector    = 0
+    case kProportionalCJKRomanSelector = 1
+    case kDefaultCJKRomanSelector      = 2
+    case kFullWidthCJKRomanSelector    = 3
+}

--- a/Sample011-Text/Sample011-Text/KerningTestView.swift
+++ b/Sample011-Text/Sample011-Text/KerningTestView.swift
@@ -1,0 +1,130 @@
+//
+//  KerningTestView.swift
+//  Sample011-Text
+//
+//  Created by ragingo on 2022/10/02.
+//
+
+import SwiftUI
+
+struct KerningTestView: View {
+    @State private var kerning: CGFloat = 0.0
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Button("Reset") {
+                kerning = 0
+            }
+            .buttonStyle(.bordered)
+            .frame(alignment: .center)
+
+            VStack {
+                Slider(
+                    value: $kerning,
+                    in: -100.0...100.0,
+                    step: 1.0,
+                    label: { EmptyView() },
+                    minimumValueLabel: { Text("-100") },
+                    maximumValueLabel: { Text("100") }
+                )
+                HStack {
+                    Text("\(Int(kerning))")
+                }
+            }
+
+            makeText(string: "123,456,789", kerning: $kerning, size: 30)
+            makeText(string: "Hello, world!", kerning: $kerning, size: 30)
+            makeText(string: "Hello,ffilw,123,!=", kerning: $kerning, size: 30)
+            makeText(string: "【Hello,ffilw,123,!=】", kerning: $kerning, size: 30)
+            makeText(string: "あいう、えお、１２３", kerning: $kerning, size: 30)
+            makeText(string: "【あいう、えお、１２３】", kerning: $kerning, size: 30)
+            makeText(string: "（あいう、えお、１２３）", kerning: $kerning, size: 30)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    @ViewBuilder
+    private func makeText(string: String, kerning: Binding<CGFloat>, size: CGFloat) -> some View {
+        if let font = createFont(size: size) {
+            Text(string)
+                .font(Font(font))
+//                .kerning(kerning.wrappedValue)
+                .border(.black)
+                .background(.blue.opacity(0.2))
+        } else {
+            Text("(T_T)")
+        }
+    }
+
+    // https://learn.microsoft.com/ja-jp/typography/opentype/spec/features_pt#tag-palt
+    // https://qiita.com/usagimaru/items/0d3c66618df43df93345#ctfontdescriptorcreatecopywithvariation
+    //   - iOS は TrueType ベースの Apple Advanced Typography (AAT)
+    //   - palt は無い
+    // https://developer.apple.com/fonts/TrueType-Reference-Manual/RM09/AppendixF.html
+    // https://ics.media/entry/14087/
+    //   - iPhone Safari & Chrome で palt が効いているのを確認
+    // 【】 について: https://0g0.org/category/3000-303F/1/
+    // https://helpx.adobe.com/jp/fonts/using/open-type-syntax.html#palt
+    //   - iOS は非対応らしい。ブラウザ側で CoteText で自分で描画しているから palt が効いている？
+    // https://qiita.com/usagimaru/items/da88c0a8793f23633c28#nsfont--uifont-%E3%81%A7-font-features-%E3%82%92%E5%88%A9%E7%94%A8%E3%81%99%E3%82%8B
+    //   - TextEdit.app タイポグラフィーパネルにて全ての「文字間隔」をいじったが、意図した動作をしなかった。
+    //     - 「半角」だけ見た目はよさそう。ただ、これを使う場合は隅付き括弧にだけ適用する必要がありそう。
+    //     - 「プロポーショナル幅」に期待していたが、全く変化なし
+
+//    private func createFont2(size: CGFloat) -> CTFont? {
+//        let featureSettings = [
+//            UIFontDescriptor.FeatureKey.type: kSmartSwashType,
+//            UIFontDescriptor.FeatureKey.selector: kWordInitialSwashesOnSelector
+//        ]
+//        guard let font = UIFont(name: "Hiragino Kaku Gothic ProN", size: size) else {
+//            return nil
+//        }
+//        let desc = font.fontDescriptor.addingAttributes([
+//            .featureSettings: [
+//                [
+//                    UIFontDescriptor.FeatureKey.type: kNumberSpacingType,
+//                    UIFontDescriptor.FeatureKey.selector: kProportionalNumbersSelector
+//                ]
+//            ]
+//        ])
+//        return UIFont(descriptor: desc, size: size) as CTFont
+//    }
+
+    private func createFont(size: CGFloat) -> CTFont? {
+        guard let font = CTFontCreateUIFontForLanguage(.user, size, nil) else {
+            return nil
+        }
+
+        let fontFeatureSettings: [CFDictionary] = [
+            [
+                kCTFontFeatureTypeIdentifierKey:     kNumberSpacingType,
+                kCTFontFeatureSelectorIdentifierKey: kProportionalNumbersSelector
+            ] as CFDictionary,
+            [
+                kCTFontFeatureTypeIdentifierKey:     kTextSpacingType,
+                kCTFontFeatureSelectorIdentifierKey: kProportionalTextSelector
+            ] as CFDictionary,
+            [
+                kCTFontFeatureTypeIdentifierKey:     kIdeographicSpacingType,
+                kCTFontFeatureSelectorIdentifierKey: kProportionalIdeographsSelector
+            ] as CFDictionary,
+            [
+                kCTFontFeatureTypeIdentifierKey:     kCJKRomanSpacingType,
+                kCTFontFeatureSelectorIdentifierKey: kProportionalCJKRomanSelector
+            ] as CFDictionary,
+        ]
+
+        let fontDescriptor = CTFontDescriptorCreateWithAttributes([
+            kCTFontFeatureSettingsAttribute: fontFeatureSettings
+        ] as CFDictionary)
+
+        let fontWithFeatures = CTFontCreateCopyWithAttributes(font, size, nil, fontDescriptor)
+        return fontWithFeatures
+    }
+}
+
+struct KerningTestView_Previews: PreviewProvider {
+    static var previews: some View {
+        KerningTestView()
+    }
+}

--- a/Sample011-Text/Sample011-Text/KerningTestView.swift
+++ b/Sample011-Text/Sample011-Text/KerningTestView.swift
@@ -19,6 +19,9 @@ struct KerningTestView: View {
             .frame(alignment: .center)
 
             VStack {
+                HStack {
+                    Text("Kerning: \(Int(kerning))")
+                }
                 Slider(
                     value: $kerning,
                     in: -100.0...100.0,
@@ -27,99 +30,27 @@ struct KerningTestView: View {
                     minimumValueLabel: { Text("-100") },
                     maximumValueLabel: { Text("100") }
                 )
-                HStack {
-                    Text("\(Int(kerning))")
-                }
             }
 
             makeText(string: "123,456,789", kerning: $kerning, size: 30)
             makeText(string: "Hello, world!", kerning: $kerning, size: 30)
             makeText(string: "Hello,ffilw,123,!=", kerning: $kerning, size: 30)
-            makeText(string: "【Hello,ffilw,123,!=】", kerning: $kerning, size: 30)
-            makeText(string: "あいう、えお、１２３", kerning: $kerning, size: 30)
-            makeText(string: "【あいう、えお、１２３】", kerning: $kerning, size: 30)
-            makeText(string: "（あいう、えお、１２３）", kerning: $kerning, size: 30)
+            makeText(string: "あいうえおかきくけこ", kerning: $kerning, size: 30)
+            makeText(string: "あ、い。１２３", kerning: $kerning, size: 30)
+            makeText(string: "【あ】い", kerning: $kerning, size: 30)
+            makeText(string: "（あ）い", kerning: $kerning, size: 30)
         }
         .frame(maxWidth: .infinity)
+        .navigationTitle("Kerning")
     }
 
     @ViewBuilder
     private func makeText(string: String, kerning: Binding<CGFloat>, size: CGFloat) -> some View {
-        if let font = createFont(size: size) {
-            Text(string)
-                .font(Font(font))
-//                .kerning(kerning.wrappedValue)
-                .border(.black)
-                .background(.blue.opacity(0.2))
-        } else {
-            Text("(T_T)")
-        }
-    }
-
-    // https://learn.microsoft.com/ja-jp/typography/opentype/spec/features_pt#tag-palt
-    // https://qiita.com/usagimaru/items/0d3c66618df43df93345#ctfontdescriptorcreatecopywithvariation
-    //   - iOS は TrueType ベースの Apple Advanced Typography (AAT)
-    //   - palt は無い
-    // https://developer.apple.com/fonts/TrueType-Reference-Manual/RM09/AppendixF.html
-    // https://ics.media/entry/14087/
-    //   - iPhone Safari & Chrome で palt が効いているのを確認
-    // 【】 について: https://0g0.org/category/3000-303F/1/
-    // https://helpx.adobe.com/jp/fonts/using/open-type-syntax.html#palt
-    //   - iOS は非対応らしい。ブラウザ側で CoteText で自分で描画しているから palt が効いている？
-    // https://qiita.com/usagimaru/items/da88c0a8793f23633c28#nsfont--uifont-%E3%81%A7-font-features-%E3%82%92%E5%88%A9%E7%94%A8%E3%81%99%E3%82%8B
-    //   - TextEdit.app タイポグラフィーパネルにて全ての「文字間隔」をいじったが、意図した動作をしなかった。
-    //     - 「半角」だけ見た目はよさそう。ただ、これを使う場合は隅付き括弧にだけ適用する必要がありそう。
-    //     - 「プロポーショナル幅」に期待していたが、全く変化なし
-
-//    private func createFont2(size: CGFloat) -> CTFont? {
-//        let featureSettings = [
-//            UIFontDescriptor.FeatureKey.type: kSmartSwashType,
-//            UIFontDescriptor.FeatureKey.selector: kWordInitialSwashesOnSelector
-//        ]
-//        guard let font = UIFont(name: "Hiragino Kaku Gothic ProN", size: size) else {
-//            return nil
-//        }
-//        let desc = font.fontDescriptor.addingAttributes([
-//            .featureSettings: [
-//                [
-//                    UIFontDescriptor.FeatureKey.type: kNumberSpacingType,
-//                    UIFontDescriptor.FeatureKey.selector: kProportionalNumbersSelector
-//                ]
-//            ]
-//        ])
-//        return UIFont(descriptor: desc, size: size) as CTFont
-//    }
-
-    private func createFont(size: CGFloat) -> CTFont? {
-        guard let font = CTFontCreateUIFontForLanguage(.user, size, nil) else {
-            return nil
-        }
-
-        let fontFeatureSettings: [CFDictionary] = [
-            [
-                kCTFontFeatureTypeIdentifierKey:     kNumberSpacingType,
-                kCTFontFeatureSelectorIdentifierKey: kProportionalNumbersSelector
-            ] as CFDictionary,
-            [
-                kCTFontFeatureTypeIdentifierKey:     kTextSpacingType,
-                kCTFontFeatureSelectorIdentifierKey: kProportionalTextSelector
-            ] as CFDictionary,
-            [
-                kCTFontFeatureTypeIdentifierKey:     kIdeographicSpacingType,
-                kCTFontFeatureSelectorIdentifierKey: kProportionalIdeographsSelector
-            ] as CFDictionary,
-            [
-                kCTFontFeatureTypeIdentifierKey:     kCJKRomanSpacingType,
-                kCTFontFeatureSelectorIdentifierKey: kProportionalCJKRomanSelector
-            ] as CFDictionary,
-        ]
-
-        let fontDescriptor = CTFontDescriptorCreateWithAttributes([
-            kCTFontFeatureSettingsAttribute: fontFeatureSettings
-        ] as CFDictionary)
-
-        let fontWithFeatures = CTFontCreateCopyWithAttributes(font, size, nil, fontDescriptor)
-        return fontWithFeatures
+        Text(string)
+            .font(.largeTitle)
+            .kerning(kerning.wrappedValue)
+            .border(.black)
+            .background(.blue.opacity(0.2))
     }
 }
 

--- a/Sample011-Text/Sample011-Text/Preview Content/Preview Assets.xcassets/Contents.json
+++ b/Sample011-Text/Sample011-Text/Preview Content/Preview Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Sample011-Text/Sample011-Text/Sample011_TextApp.swift
+++ b/Sample011-Text/Sample011-Text/Sample011_TextApp.swift
@@ -1,0 +1,17 @@
+//
+//  Sample011_TextApp.swift
+//  Sample011-Text
+//
+//  Created by ragingo on 2022/10/02.
+//
+
+import SwiftUI
+
+@main
+struct Sample011_TextApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}


### PR DESCRIPTION
# メモ

OpenType の palt 相当のことがやりたかったけど実現できなかった・・・。
TextEdit.app でも、`【` をプロポーショナル幅にしても変化がなかった。

![image](https://user-images.githubusercontent.com/4784032/193606222-e539cb67-b2ef-4904-b839-6d5cb299858c.png)



# 画面イメージ

<img width="500px" src="https://user-images.githubusercontent.com/4784032/193605775-d5feb412-9aca-4c54-8ba7-702d0e49c220.png">